### PR TITLE
Let is_equal_to() work with anything that implements the TIOObject trait.

### DIFF
--- a/io-kit/src/base.rs
+++ b/io-kit/src/base.rs
@@ -228,7 +228,7 @@ pub trait TIOObject<concrete_io_object_t> {
         unsafe { IOObjectConformsTo(self.as_io_object_t(), class_name) != 0 }
     }
 
-    fn is_equal_to(&self, object: IOObject) -> bool {
+    fn is_equal_to(&self, object: &impl TIOObject<concrete_io_object_t>) -> bool {
         unsafe { IOObjectIsEqualTo(self.as_io_object_t(), object.as_io_object_t()) != 0 }
     }
 


### PR DESCRIPTION
Hi, this patch uses anonymous type parameters to make `is_equal_to()` more convenient. It could also be implemented using a generic function (but what fun would that be? 😉).

It also makes the object a reference which makes it more ergonomic in practice since `IOService` and `IOObject` are not `Copy` or `Clone`.